### PR TITLE
add "monitoring" in Value STATUS

### DIFF
--- a/templates/cisco_ios_show_interfaces_status.textfsm
+++ b/templates/cisco_ios_show_interfaces_status.textfsm
@@ -1,6 +1,6 @@
 Value PORT (\S+)
 Value NAME (.+?)
-Value STATUS (err-disabled|disabled|connected|notconnect|inactive|up|down)
+Value STATUS (err-disabled|disabled|connected|notconnect|inactive|up|down|monitoring)
 Value VLAN (\S+)
 Value DUPLEX (\S+)
 Value SPEED (\S+)


### PR DESCRIPTION


##### ISSUE TYPE
Template for ios_show_interfaces_status does not capture ports that are in "monitoring" status.

##### COMPONENT
Template: cisco_ios_show_interfaces_status.textfsm
IOS Command: show interfaces status

##### SUMMARY
Add "monitoring" as possible port status. This status is seen when the port is configured for port mirroring (SPAN). Currently, TextFSM will ignore this line as the line will not match any of the existing allowed status in "Value STATUS".
